### PR TITLE
Add missing methods from serializer interface

### DIFF
--- a/src/Contracts/SerializerInterface.php
+++ b/src/Contracts/SerializerInterface.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace WayOfDev\Serializer\Contracts;
 
+use ArrayObject;
 use Stringable;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 
 interface SerializerInterface
 {
@@ -12,5 +14,28 @@ interface SerializerInterface
 
     public function unserialize(string|Stringable $payload, string|object $type = null): mixed;
 
-    public function normalize(mixed $data, string $format = null, array $context = []);
+    /**
+     * @param mixed       $data
+     * @param string|null $format
+     * @param array       $context
+     *
+     * @throws ExceptionInterface
+     *
+     * @return array|string|int|float|bool|ArrayObject|null
+     */
+    public function normalize(mixed $data, string $format = null, array $context = []): array | string | int | float | bool | ArrayObject | null;
+
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed;
+
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool;
+
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool;
+
+    public function encode(mixed $data, string $format, array $context = []);
+
+    public function decode(string $data, string $format, array $context = []);
+
+    public function supportsEncoding(string $format, array $context = []): bool;
+
+    public function supportsDecoding(string $format, array $context = []): bool;
 }

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -6,7 +6,6 @@ namespace WayOfDev\Serializer;
 
 use ArrayObject;
 use Stringable;
-use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Serializer as SymfonySerializer;
 use WayOfDev\Serializer\Contracts\SerializerInterface;
 use WayOfDev\Serializer\Exceptions\UnsupportedTypeException;
@@ -43,9 +42,6 @@ readonly class Serializer implements SerializerInterface
         );
     }
 
-    /**
-     * @throws ExceptionInterface
-     */
     public function normalize(
         mixed $data,
         string $format = null,

--- a/src/SerializerManager.php
+++ b/src/SerializerManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WayOfDev\Serializer;
 
+use ArrayObject;
 use Stringable;
 use WayOfDev\Serializer\Contracts\SerializerInterface;
 
@@ -33,8 +34,57 @@ readonly class SerializerManager implements SerializerInterface
         return $this->getSerializer($format ?? $this->defaultFormat)->unserialize($payload, $type);
     }
 
-    public function normalize(mixed $data, string $format = null, array $context = [])
+    public function normalize(mixed $data, string $format = null, array $context = []): array | string | int | float | bool | ArrayObject | null
     {
         return $this->getSerializer($format ?? $this->defaultFormat)->normalize($data, $format, $context);
+    }
+
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): mixed
+    {
+        $format ??= $this->defaultFormat;
+
+        return $this->getSerializer($format)->denormalize($data, $type, $format, $context);
+    }
+
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    {
+        $format ??= $this->defaultFormat;
+
+        return $this->getSerializer($format)->supportsNormalization($data, $format, $context);
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    {
+        $format ??= $this->defaultFormat;
+
+        return $this->getSerializer($format)->supportsDenormalization($data, $type, $format, $context);
+    }
+
+    public function encode(mixed $data, string $format, array $context = [])
+    {
+        $format ??= $this->defaultFormat;
+
+        return $this->getSerializer($format)->encode($data, $format, $context);
+    }
+
+    public function decode(string $data, string $format, array $context = [])
+    {
+        $format ??= $this->defaultFormat;
+
+        return $this->getSerializer($format)->decode($data, $format, $context);
+    }
+
+    public function supportsEncoding(string $format, array $context = []): bool
+    {
+        $format ??= $this->defaultFormat;
+
+        return $this->getSerializer($format)->supportsEncoding($format, $context);
+    }
+
+    public function supportsDecoding(string $format, array $context = []): bool
+    {
+        $format ??= $this->defaultFormat;
+
+        return $this->getSerializer($format)->supportsDecoding($format, $context);
     }
 }


### PR DESCRIPTION
This PR adds methods available  in the symfony serializer to the SerializerInterface such as `denormalize` and `supportsDenormalization` and similar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the serialization functionality with new methods for denormalization, encoding, and decoding.
  - Introduced support checking methods for normalization, denormalization, encoding, and decoding.
  
- **Improvements**
  - Updated the `normalize` method to specify return type hints and handle additional return types for better flexibility and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->